### PR TITLE
Fix CORS middleware setup and file extension handling

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -14,9 +14,10 @@ app = FastAPI()
 
 from fastapi.middleware.cors import CORSMiddleware
 
+# Configure CORS. `CORS_ORIGINS` is already a list, so pass it directly
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[CORS_ORIGINS],  # NEVER use "*" in production
+    allow_origins=CORS_ORIGINS,  # NEVER use "*" in production
     allow_methods=["*"],
     allow_headers=["*"]
 )

--- a/ingestion/file_loader.py
+++ b/ingestion/file_loader.py
@@ -8,11 +8,11 @@ SUPPORTED_EXTENSIONS = ALLOWED_FILE_EXTENSIONS
 def collect_files_from_path(path):
     files = []
     path = Path(path)
-    if path.is_file() and path.suffix in SUPPORTED_EXTENSIONS:
+    if path.is_file() and path.suffix.lower() in SUPPORTED_EXTENSIONS:
         files.append(path)
     elif path.is_dir():
         for file in path.rglob("*"):
-            if file.suffix in SUPPORTED_EXTENSIONS:
+            if file.suffix.lower() in SUPPORTED_EXTENSIONS:
                 files.append(file)
     return files
 


### PR DESCRIPTION
## Summary
- pass configured CORS origins list directly to `CORSMiddleware`
- normalize file extensions in `collect_files_from_path`

## Testing
- `python -m py_compile api/app.py ingestion/file_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c4e1f615c8330b72a493b6f680271