### PR TITLE
Add API key authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for Knowledge Indexer
+OPENAI_API_KEY=sk-your-openai-key
+# Comma-separated list of API keys allowed to access the API
+API_KEYS=your-generated-api-key

--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ A local knowledge management solution built with **FastAPI** and **Streamlit** t
 pip install -r requirements.txt
 ```
 
-> Create a `.env` file with your OpenAI key:
+> Create a `.env` file with your OpenAI key and allowed API keys:
 ```
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxx
+# Comma-separated list of keys permitted to access the API
+API_KEYS=your-api-key-1,your-api-key-2
 ```
 
 ---
@@ -74,6 +76,19 @@ python run_app.py
 Then open:
 - FastAPI backend: http://127.0.0.1:8000/docs
 - Streamlit UI: http://localhost:8501
+
+---
+
+### 🔐 API Authentication
+
+All FastAPI routes are protected with an API key. Generate a key (for example,
+`python -c "import secrets; print(secrets.token_hex(16))"`), add it to
+`API_KEYS` in your `.env` file, and include it with requests using the
+`X-API-Key` header:
+
+```bash
+curl -H "X-API-Key: <your-api-key>" http://127.0.0.1:8000/list-indexes/
+```
 
 ---
 

--- a/api/app.py
+++ b/api/app.py
@@ -1,6 +1,6 @@
 """FastAPI routes for managing document indexes and querying them."""
 
-from fastapi import FastAPI, File, UploadFile, Form
+from fastapi import FastAPI, File, UploadFile, Form, Depends
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -24,6 +24,7 @@ import asyncio
 from typing import Iterable, List
 from pathlib import Path
 from config import CORS_ORIGINS
+from .auth import verify_api_key
 
 app = FastAPI()
 
@@ -102,7 +103,7 @@ async def process_files(files: Iterable[UploadFile], collection: str, chunker=to
         return len(all_chunks)
     return 0
 
-@app.post("/create-index/")
+@app.post("/create-index/", dependencies=[Depends(verify_api_key)])
 async def create_index(collection: str = Form(...), files: list[UploadFile] = File(...)):
     """Create a new collection and ingest the given files."""
     try:
@@ -113,7 +114,7 @@ async def create_index(collection: str = Form(...), files: list[UploadFile] = Fi
     except Exception as e:
         return JSONResponse(content={"error": str(e)}, status_code=500)
 
-@app.post("/update-index/")
+@app.post("/update-index/", dependencies=[Depends(verify_api_key)])
 async def update_index(collection: str = Form(...), files: list[UploadFile] = File(...)):
     """Append new files to an existing collection."""
     try:
@@ -124,7 +125,7 @@ async def update_index(collection: str = Form(...), files: list[UploadFile] = Fi
     except Exception as e:
         return JSONResponse(content={"error": str(e)}, status_code=500)
 
-@app.post("/query/")
+@app.post("/query/", dependencies=[Depends(verify_api_key)])
 async def query(request: QueryRequest):
     """Return relevant context for ``request.query`` from the index."""
     try:
@@ -135,7 +136,7 @@ async def query(request: QueryRequest):
         return JSONResponse(content={"error": str(e)}, status_code=500)
 
 
-@app.post("/multi-query/")
+@app.post("/multi-query/", dependencies=[Depends(verify_api_key)])
 async def multi_query(request: MultiQueryRequest):
     """Return context from multiple indexes for ``request.query``."""
     try:
@@ -145,7 +146,7 @@ async def multi_query(request: MultiQueryRequest):
     except Exception as e:
         return JSONResponse(content={"error": str(e)}, status_code=500)
 
-@app.get("/list-indexes/")
+@app.get("/list-indexes/", dependencies=[Depends(verify_api_key)])
 async def list_indexes():
     """List all available collections with basic metadata."""
     try:
@@ -153,7 +154,7 @@ async def list_indexes():
     except Exception as e:
         return JSONResponse(content={"error": str(e)}, status_code=500)
 
-@app.delete("/delete-index/{collection_name}")
+@app.delete("/delete-index/{collection_name}", dependencies=[Depends(verify_api_key)])
 async def delete_index(collection_name: str):
     """Delete an entire collection from the vector store."""
     result = delete_collection(collection_name)

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,0 +1,19 @@
+"""Authentication utilities for the API."""
+
+from fastapi import HTTPException, Security
+from fastapi.security import APIKeyHeader
+from starlette.status import HTTP_401_UNAUTHORIZED
+
+from config import API_KEYS
+
+api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+def verify_api_key(api_key: str = Security(api_key_header)) -> str:
+    """Validate provided API key against allowed keys."""
+    if api_key in API_KEYS:
+        return api_key
+    raise HTTPException(
+        status_code=HTTP_401_UNAUTHORIZED,
+        detail="Invalid or missing API key",
+    )

--- a/config.py
+++ b/config.py
@@ -20,6 +20,10 @@ VECTOR_DB_PATH = os.getenv("VECTOR_DB_PATH", str(BASE_DIR / "data" / "vector_ind
 # === FastAPI Settings ===
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:8501").split(",")
 
+# === API Key Authentication ===
+# Comma-separated list of API keys that can access the API
+API_KEYS = {key.strip() for key in os.getenv("API_KEYS", "").split(",") if key.strip()}
+
 # === File Upload Settings ===
 ALLOWED_FILE_EXTENSIONS = {".pdf", ".docx", ".txt", ".md"}
 MAX_FILE_SIZE_MB = int(os.getenv("MAX_FILE_SIZE_MB", "25"))


### PR DESCRIPTION
## Summary
- secure all FastAPI routes with an API key dependency
- document and configure API key support via environment variables

## Testing
- `pytest`
- `python -m py_compile config.py api/auth.py api/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688db2588c788330bf4a506f7098bbeb