### PR TITLE
feat: unify query endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A local knowledge management solution built with **FastAPI** and **Streamlit** t
 - ✅ Automatically chunk and embed content
 - ✅ Store embeddings locally using ChromaDB
 - ✅ Create and update custom indexes (collections)
-- ✅ Query indexed knowledge and retrieve context
+- ✅ Query indexed knowledge across single or multiple indexes
 - ✅ View all collections and their metadata
 - ✅ Delete collections safely from the UI
 - ✅ Full Python backend & frontend integration
@@ -98,8 +98,7 @@ curl -H "X-API-Key: <your-api-key>" http://127.0.0.1:8000/list-indexes/
 |--------|---------------------------|----------------------------------|
 | POST   | `/create-index/`          | Upload files and create index   |
 | POST   | `/update-index/`          | Add files to existing index     |
-| POST   | `/query/`                 | Ask questions about an index    |
-| POST   | `/multi-query/`           | Search across multiple indexes |
+| POST   | `/query/`                 | Search one, many, or all indexes |
 | GET    | `/list-indexes/`          | View collections and metadata   |
 | DELETE | `/delete-index/{name}`    | Delete a collection             |
 

--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -84,17 +84,25 @@ elif page == "Query Index":
     else:
         st.info("Enter API key to load indexes.")
 
-    selected_indexes = st.multiselect("Select indexes", options=index_options)
+    selected_indexes = st.multiselect(
+        "Select indexes (leave empty to search all)", options=index_options
+    )
     query = st.text_input("Ask a question")
 
-    if st.button("Submit Query") and query and selected_indexes:
+    if st.button("Submit Query") and query:
         if not api_key:
             st.error("API key required.")
         else:
+            payload = {"query": query}
+            if selected_indexes:
+                if len(selected_indexes) == 1:
+                    payload["collection"] = selected_indexes[0]
+                else:
+                    payload["collections"] = selected_indexes
             with st.spinner("Thinking..."):
                 res = requests.post(
-                    f"{API_URL}/multi-query/",
-                    json={"query": query, "collections": selected_indexes},
+                    f"{API_URL}/query/",
+                    json=payload,
                     headers=headers,
                 )
 

--- a/vector_store/vector_index.py
+++ b/vector_store/vector_index.py
@@ -17,6 +17,10 @@ def add_documents_to_index(collection_name, documents, embeddings, metadatas, id
     collection = get_or_create_collection(collection_name)
     collection.add(documents=documents, embeddings=embeddings, metadatas=metadatas, ids=ids)
 
+def list_collection_names() -> list[str]:
+    """Return a list of all collection names in the vector store."""
+    return [col.name for col in client.list_collections()]
+
 def query_index(collection_name, query_text, n_results=5):
     """Query ``collection_name`` using the embedding of ``query_text``."""
     from vector_store.embedder import get_openai_embedding


### PR DESCRIPTION
## Summary
- add helper to list available collection names
- consolidate `/query/` and `/multi-query/` into a single dynamic endpoint
- update Streamlit UI and README to use unified query behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dc029ba708330ba37de5ab71940c8