### PR TITLE
Implement user accounts with per-user vector DBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A local knowledge management solution built with **FastAPI** and **Streamlit** t
 - ✅ View all collections and their metadata
 - ✅ Delete collections safely from the UI
 - ✅ Full Python backend & frontend integration
+- ✅ User accounts with per-user vector stores and API keys
 
 ---
 
@@ -48,11 +49,9 @@ A local knowledge management solution built with **FastAPI** and **Streamlit** t
 pip install -r requirements.txt
 ```
 
-> Create a `.env` file with your OpenAI key and allowed API keys:
+> Create a `.env` file with your OpenAI key:
 ```
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxx
-# Comma-separated list of keys permitted to access the API
-API_KEYS=your-api-key-1,your-api-key-2
 ```
 
 ---
@@ -79,16 +78,31 @@ Then open:
 
 ---
 
-### 🔐 API Authentication
+### 🔐 User Accounts & API Keys
 
-All FastAPI routes are protected with an API key. Generate a key (for example,
-`python -c "import secrets; print(secrets.token_hex(16))"`), add it to
-`API_KEYS` in your `.env` file, and include it with requests using the
-`X-API-Key` header:
+Each user has a private vector database and can generate their own API keys.
 
-```bash
-curl -H "X-API-Key: <your-api-key>" http://127.0.0.1:8000/list-indexes/
-```
+1. **Register a user**
+
+   ```bash
+   curl -X POST -H "Content-Type: application/json" \
+     -d '{"username": "alice", "password": "secret"}' \
+     http://127.0.0.1:8000/user/register
+   ```
+
+2. **Create an API key** (after registering)
+
+   ```bash
+   curl -X POST -H "Content-Type: application/json" \
+     -d '{"username": "alice", "password": "secret"}' \
+     http://127.0.0.1:8000/user/create-api-key
+   ```
+
+3. **Use the API key**
+
+   ```bash
+   curl -H "X-API-Key: <your-api-key>" http://127.0.0.1:8000/list-indexes/
+   ```
 
 ---
 
@@ -109,7 +123,7 @@ curl -H "X-API-Key: <your-api-key>" http://127.0.0.1:8000/list-indexes/
 - [ ] Full file preview in UI
 - [x] Multi-index search
 - [ ] Support for local embedding models (offline mode)
-- [ ] User authentication
+- [x] User authentication
 - [ ] Export/Import indexes
 
 ---

--- a/api/auth.py
+++ b/api/auth.py
@@ -4,15 +4,16 @@ from fastapi import HTTPException, Security
 from fastapi.security import APIKeyHeader
 from starlette.status import HTTP_401_UNAUTHORIZED
 
-from config import API_KEYS
+from .users import get_user_by_api_key
 
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 
-def verify_api_key(api_key: str = Security(api_key_header)) -> str:
-    """Validate provided API key against allowed keys."""
-    if api_key in API_KEYS:
-        return api_key
+def get_current_user(api_key: str = Security(api_key_header)) -> dict:
+    """Return the user associated with the provided API key."""
+    user = get_user_by_api_key(api_key)
+    if user:
+        return user
     raise HTTPException(
         status_code=HTTP_401_UNAUTHORIZED,
         detail="Invalid or missing API key",

--- a/api/users.py
+++ b/api/users.py
@@ -1,0 +1,147 @@
+"""User management and API key generation utilities."""
+
+import sqlite3
+import hashlib
+import secrets
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from config import BASE_DIR, VECTOR_DB_PATH
+
+# Database location for user accounts and API keys
+DB_PATH = Path(BASE_DIR) / "users.db"
+
+
+def _get_conn():
+    return sqlite3.connect(DB_PATH)
+
+
+def init_db():
+    """Create tables for users and API keys if they don't already exist."""
+    conn = _get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            password_hash TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS api_keys (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            key TEXT UNIQUE NOT NULL,
+            user_id INTEGER NOT NULL,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+# Ensure DB exists on import
+init_db()
+
+router = APIRouter()
+
+
+class UserCredentials(BaseModel):
+    username: str
+    password: str
+
+
+def _hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def _verify_password(password: str, password_hash: str) -> bool:
+    return _hash_password(password) == password_hash
+
+
+@router.post("/register")
+def register(user: UserCredentials):
+    """Register a new user and create a vector DB directory for them."""
+    conn = _get_conn()
+    try:
+        conn.execute(
+            "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+            (user.username, _hash_password(user.password)),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError:
+        conn.close()
+        raise HTTPException(status_code=400, detail="Username already exists")
+    conn.close()
+
+    # Ensure user-specific vector DB directory exists
+    user_path = Path(VECTOR_DB_PATH) / user.username
+    user_path.mkdir(parents=True, exist_ok=True)
+
+    return {"message": "User registered"}
+
+
+@router.post("/login")
+def login(user: UserCredentials):
+    """Validate user credentials and return existing API keys."""
+    conn = _get_conn()
+    cur = conn.execute(
+        "SELECT id, password_hash FROM users WHERE username=?", (user.username,)
+    )
+    row = cur.fetchone()
+    if not row or not _verify_password(user.password, row[1]):
+        conn.close()
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    user_id = row[0]
+    cur = conn.execute("SELECT key FROM api_keys WHERE user_id=?", (user_id,))
+    keys = [r[0] for r in cur.fetchall()]
+    conn.close()
+    return {"message": "Login successful", "api_keys": keys}
+
+
+@router.post("/create-api-key")
+def create_api_key(user: UserCredentials):
+    """Generate a new API key for a user after verifying credentials."""
+    conn = _get_conn()
+    cur = conn.execute(
+        "SELECT id, password_hash FROM users WHERE username=?", (user.username,)
+    )
+    row = cur.fetchone()
+    if not row or not _verify_password(user.password, row[1]):
+        conn.close()
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    user_id = row[0]
+    api_key = secrets.token_hex(16)
+    conn.execute(
+        "INSERT INTO api_keys (key, user_id) VALUES (?, ?)", (api_key, user_id)
+    )
+    conn.commit()
+    conn.close()
+    return {"api_key": api_key}
+
+
+def get_user_by_api_key(api_key: str) -> dict | None:
+    """Return user details for a given API key or ``None`` if not found."""
+    conn = _get_conn()
+    cur = conn.execute(
+        """
+        SELECT users.id, users.username
+        FROM api_keys
+        JOIN users ON api_keys.user_id = users.id
+        WHERE api_keys.key = ?
+        """,
+        (api_key,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    if row:
+        user_id, username = row
+        user_path = Path(VECTOR_DB_PATH) / username
+        user_path.mkdir(parents=True, exist_ok=True)
+        return {"id": user_id, "username": username, "db_path": str(user_path)}
+    return None

--- a/config.py
+++ b/config.py
@@ -20,10 +20,6 @@ VECTOR_DB_PATH = os.getenv("VECTOR_DB_PATH", str(BASE_DIR / "data" / "vector_ind
 # === FastAPI Settings ===
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:8501").split(",")
 
-# === API Key Authentication ===
-# Comma-separated list of API keys that can access the API
-API_KEYS = {key.strip() for key in os.getenv("API_KEYS", "").split(",") if key.strip()}
-
 # === File Upload Settings ===
 ALLOWED_FILE_EXTENSIONS = {".pdf", ".docx", ".txt", ".md"}
 MAX_FILE_SIZE_MB = int(os.getenv("MAX_FILE_SIZE_MB", "25"))


### PR DESCRIPTION
## Summary
- add user registration, login, and API key generation backed by SQLite
- tie API authentication to user-specific vector store paths
- update documentation for new user-driven workflow and remove global API key setting

## Testing
- `python -m py_compile api/app.py api/auth.py api/users.py vector_store/vector_index.py`
- `python -m py_compile config.py`


------
https://chatgpt.com/codex/tasks/task_e_688dc7cad2f88330a4db072514e6a088