### PR TITLE
refactor: centralize API calls in UI

### DIFF
--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -1,0 +1,46 @@
+import os
+import logging
+from typing import Any
+
+import requests
+
+API_URL = os.getenv("API_URL", "https://knowledge-manager-236c8288fac7.herokuapp.com/").rstrip("/")
+
+logger = logging.getLogger(__name__)
+
+
+def api_request(method: str, path: str, **kwargs: Any) -> requests.Response:
+    """Make an API request to the backend service.
+
+    Parameters
+    ----------
+    method:
+        HTTP method, e.g. "get", "post", "delete".
+    path:
+        Endpoint path that will be joined with ``API_URL``.
+    **kwargs:
+        Additional arguments passed to ``requests.request`` (e.g. headers, json).
+
+    Returns
+    -------
+    requests.Response
+        The response object from ``requests``.
+    """
+    url = f"{API_URL}/{path.lstrip('/') }"
+    headers = kwargs.pop("headers", {}) or {}
+    headers.setdefault("Accept", "application/json")
+
+    try:
+        response = requests.request(method, url, headers=headers, **kwargs)
+        if response.status_code >= 400:
+            logger.error(
+                "API request failed: %s %s -> %s %s",
+                method.upper(),
+                url,
+                response.status_code,
+                response.text,
+            )
+        return response
+    except requests.RequestException as exc:
+        logger.error("API request exception: %s %s -> %s", method.upper(), url, exc)
+        raise


### PR DESCRIPTION
## Summary
- add `ui/api_client.py` with `api_request` helper for base URL handling and error logging
- refactor `streamlit_app.py` to use the new helper instead of direct `requests`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef6db3420833089df75e8d22cf90c