### PR TITLE
Add documentation page for using indexed files

### DIFF
--- a/ui/pages/documentation.py
+++ b/ui/pages/documentation.py
@@ -1,0 +1,63 @@
+import streamlit as st
+
+st.markdown("### Documentation")
+
+st.markdown(
+    """
+Use the Knowledge Manager API to query files you have uploaded and indexed.\
+ This example shows how to retrieve context for a user query and pass it to the OpenAI Responses API.
+"""
+)
+
+code = '''from openai import OpenAI
+import requests
+import json
+from dotenv import load_dotenv
+import os
+
+def query_remote_vector_db(url, query, api_key, collections=None):
+    endpoint = url + '/query'
+
+    data = {
+        'query' : query
+    }
+    
+    if collections:
+        data['collections'] = collections
+
+    headers = {
+        'Content-Type' : 'application/json',
+        'x-api-key' : api_key
+    }
+
+    return requests.post(endpoint, json=data, headers=headers).json()
+
+load_dotenv()
+
+client = OpenAI()
+
+api_key = "<your-knowledge-manager-api-key>"
+url = "https://knowledge-manager-236c8288fac7.herokuapp.com/"  # temp endpoint
+
+user_query = "<your query here>"
+
+context = query_remote_vector_db(url, user_query, api_key)
+
+inp = f"""
+
+Here is a user request:
+{user_query}
+
+Context Dump:
+{json.dumps(context)}
+"""
+
+response = client.responses.create(
+    model="gpt-4o",
+    input=inp
+)
+
+print(response.output_text)
+'''
+
+st.code(code, language='python')

--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -24,6 +24,7 @@ def main() -> None:
         st.Page("pages/upload.py", title="Upload Files", icon="📤"),
         st.Page("pages/query.py", title="Query Index", icon="🔍"),
         st.Page("pages/indexes.py", title="View Indexes", icon="📁"),
+        st.Page("pages/documentation.py", title="Documentation", icon="📖"),
         st.Page("pages/account.py", title="Account", icon="🔐"),
     ]
     pg = st.navigation(pages)


### PR DESCRIPTION
## Summary
- Add a new documentation page in the Streamlit UI demonstrating how to query indexed files via the Knowledge Manager API
- Include the new Documentation page in the main Streamlit navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f144bf50883309009da20cd8dc2c8