### PR TITLE
Prefix API routes with /api

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Each user has a private vector database and can generate their own API keys.
    ```bash
    curl -X POST -H "Content-Type: application/json" \
      -d '{"username": "alice", "password": "secret"}' \
-     http://127.0.0.1:8000/user/register
+     http://127.0.0.1:8000/api/user/register
    ```
 
 2. **Create an API key** (after registering)
@@ -95,13 +95,13 @@ Each user has a private vector database and can generate their own API keys.
    ```bash
    curl -X POST -H "Content-Type: application/json" \
      -d '{"username": "alice", "password": "secret"}' \
-     http://127.0.0.1:8000/user/create-api-key
+     http://127.0.0.1:8000/api/user/create-api-key
    ```
 
 3. **Use the API key**
 
    ```bash
-   curl -H "X-API-Key: <your-api-key>" http://127.0.0.1:8000/list-indexes/
+   curl -H "X-API-Key: <your-api-key>" http://127.0.0.1:8000/api/list-indexes/
    ```
 
 ---
@@ -110,17 +110,17 @@ Each user has a private vector database and can generate their own API keys.
 
 | Method | Endpoint                  | Description                      |
 |--------|---------------------------|----------------------------------|
-| POST   | `/create-index/`          | Upload files and create index   |
-| POST   | `/update-index/`          | Add files to existing index     |
-| POST   | `/query/`                 | Search one, many, or all indexes |
-| GET    | `/list-indexes/`          | View collections and metadata   |
-| DELETE | `/delete-index/{name}`    | Delete a collection             |
+| POST   | `/api/create-index/`          | Upload files and create index   |
+| POST   | `/api/update-index/`          | Add files to existing index     |
+| POST   | `/api/query/`                 | Search one, many, or all indexes |
+| GET    | `/api/list-indexes/`          | View collections and metadata   |
+| DELETE | `/api/delete-index/{name}`    | Delete a collection             |
 
 ---
 
 ### 📄 File Upload Limits
 
-The `/create-index/` and `/update-index/` endpoints only accept files up to
+The `/api/create-index/` and `/api/update-index/` endpoints only accept files up to
 `MAX_FILE_SIZE_MB` (25 MB by default) and with extensions in
 `ALLOWED_FILE_EXTENSIONS` (`.pdf`, `.docx`, `.txt`, `.md`). Files that exceed
 these limits will result in a `400 Bad Request` response.

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -18,14 +18,14 @@ app.dependency_overrides[get_current_user] = override_get_current_user
 client = TestClient(app)
 
 
-@pytest.mark.parametrize("endpoint", ["/create-index/", "/update-index/"])
+@pytest.mark.parametrize("endpoint", ["/api/create-index/", "/api/update-index/"])
 def test_reject_invalid_extension(endpoint):
     files = [("files", ("malware.exe", b"data"))]
     response = client.post(endpoint, data={"collection": "test"}, files=files)
     assert response.status_code == 400
 
 
-@pytest.mark.parametrize("endpoint", ["/create-index/", "/update-index/"])
+@pytest.mark.parametrize("endpoint", ["/api/create-index/", "/api/update-index/"])
 def test_reject_large_file(endpoint):
     original_limit = app_module.MAX_FILE_SIZE_MB
     app_module.MAX_FILE_SIZE_MB = 0

--- a/tests/test_user_auth.py
+++ b/tests/test_user_auth.py
@@ -16,13 +16,13 @@ def test_login_returns_new_api_key(tmp_path):
 
     # Register user
     resp = client.post(
-        "/user/register", json={"username": "alice", "password": "secret"}
+        "/api/user/register", json={"username": "alice", "password": "secret"}
     )
     assert resp.status_code == 200
 
     # Login should return a new key
     resp = client.post(
-        "/user/login", json={"username": "alice", "password": "secret"}
+        "/api/user/login", json={"username": "alice", "password": "secret"}
     )
     assert resp.status_code == 200
     api_key = resp.json()["api_key"]
@@ -46,13 +46,13 @@ def test_create_api_key_generates_unique_keys(tmp_path):
     users.init_db()
 
     client = TestClient(app)
-    client.post("/user/register", json={"username": "bob", "password": "pass"})
+    client.post("/api/user/register", json={"username": "bob", "password": "pass"})
 
     resp1 = client.post(
-        "/user/create-api-key", json={"username": "bob", "password": "pass"}
+        "/api/user/create-api-key", json={"username": "bob", "password": "pass"}
     )
     resp2 = client.post(
-        "/user/create-api-key", json={"username": "bob", "password": "pass"}
+        "/api/user/create-api-key", json={"username": "bob", "password": "pass"}
     )
 
     key1 = resp1.json()["api_key"]

--- a/ui/pages/account.py
+++ b/ui/pages/account.py
@@ -14,7 +14,7 @@ with st.form("register_form"):
 if submitted and reg_user and reg_pass:
     res = api_request(
         "post",
-        "/user/register",
+        "/api/user/register",
         json={"username": reg_user, "password": reg_pass},
     )
     if res.status_code == 200:
@@ -31,7 +31,7 @@ with st.form("login_form"):
 if login_submitted and login_user and login_pass:
     res = api_request(
         "post",
-        "/user/login",
+        "/api/user/login",
         json={"username": login_user, "password": login_pass},
     )
     if res.status_code == 200:
@@ -57,7 +57,7 @@ if st.session_state.username and st.session_state.password:
     if st.button("Create New API Key"):
         res = api_request(
             "post",
-            "/user/create-api-key",
+            "/api/user/create-api-key",
             json={
                 "username": st.session_state.username,
                 "password": st.session_state.password,

--- a/ui/pages/documentation.py
+++ b/ui/pages/documentation.py
@@ -16,7 +16,7 @@ from dotenv import load_dotenv
 import os
 
 def query_remote_vector_db(url, query, api_key, collections=None):
-    endpoint = url + '/query'
+    endpoint = url + '/api/query'
 
     data = {
         'query' : query

--- a/ui/pages/indexes.py
+++ b/ui/pages/indexes.py
@@ -8,7 +8,7 @@ st.markdown("### 💽 Existing Indexes with Metadata")
 api_key = get_api_key()
 if api_key:
     try:
-        res = api_request("get", "/list-indexes/", headers=get_headers())
+        res = api_request("get", "/api/list-indexes/", headers=get_headers())
         if res.status_code == 200:
             indexes = res.json()
 
@@ -32,7 +32,7 @@ if api_key:
                                 files = [("files", (f.name, f.getvalue())) for f in update_files]
                                 update_res = api_request(
                                     "post",
-                                    "/update-index/",
+                                    "/api/update-index/",
                                     files=files,
                                     data={"collection": index_name},
                                     headers=get_headers(),
@@ -56,7 +56,7 @@ if api_key:
                                 if st.button("✅ Yes, Delete", key=confirm_key):
                                     del_res = api_request(
                                         "delete",
-                                        f"/delete-index/{index_name}",
+                                        f"/api/delete-index/{index_name}",
                                         headers=get_headers(),
                                     )
                                     if del_res.status_code == 200:

--- a/ui/pages/query.py
+++ b/ui/pages/query.py
@@ -10,7 +10,7 @@ api_key = get_api_key()
 index_options: list[str] = []
 if api_key:
     try:
-        res = api_request("get", "/list-indexes/", headers=get_headers())
+        res = api_request("get", "/api/list-indexes/", headers=get_headers())
         if res.status_code == 200:
             index_options = [idx["collection_name"] for idx in res.json()]
     except Exception:
@@ -36,7 +36,7 @@ if st.button("Submit Query") and query:
         with st.spinner("Thinking..."):
             res = api_request(
                 "post",
-                "/query/",
+                "/api/query/",
                 json=payload,
                 headers=get_headers(),
             )

--- a/ui/pages/upload.py
+++ b/ui/pages/upload.py
@@ -49,7 +49,7 @@ if st.button("Submit Files") and user_index_name and uploaded_files:
             files = [("files", (f.name, f.getvalue())) for f in uploaded_files]
             res = api_request(
                 "post",
-                "/create-index/",
+                "/api/create-index/",
                 files=files,
                 data={"collection": collection},
                 headers=get_headers(),


### PR DESCRIPTION
## Summary
- Route all FastAPI endpoints through a new `/api` prefix and expose user routes under `/api/user`
- Adjust Streamlit pages to call the updated endpoints
- Revise README and documentation examples to reference the `/api` path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902c0c20708330a2dccaac894fab6d